### PR TITLE
Fix TaskerPluginRunner always using default NotificationProperties

### DIFF
--- a/taskerpluginlibrary/src/main/java/com/joaomgcd/taskerpluginlibrary/action/TaskerPluginRunnerAction.kt
+++ b/taskerpluginlibrary/src/main/java/com/joaomgcd/taskerpluginlibrary/action/TaskerPluginRunnerAction.kt
@@ -14,7 +14,7 @@ abstract class TaskerPluginRunnerAction<TInput : Any, TOutput : Any>() : TaskerP
     internal fun runWithIntent(context: IntentServiceParallel?, taskerIntent: Intent?) :RunnerActionResult{
         if (context == null) return RunnerActionResult(false)
         if (taskerIntent == null) return RunnerActionResult(false)
-        context.startForegroundIfNeeded()
+        startForegroundIfNeeded(context)
         try {
             val input = taskerIntent.getTaskerInput(context, getInputClass(taskerIntent))
             var result = run(context, input)

--- a/taskerpluginlibrary/src/main/java/com/joaomgcd/taskerpluginlibrary/runner/TaskerPluginRunner.kt
+++ b/taskerpluginlibrary/src/main/java/com/joaomgcd/taskerpluginlibrary/runner/TaskerPluginRunner.kt
@@ -47,6 +47,11 @@ abstract class TaskerPluginRunner<TInput : Any, TOutput : Any> {
         TaskerPluginRunner.startForegroundIfNeeded(this, notificationProperties)
     }
 
+    @TargetApi(Build.VERSION_CODES.O)
+    fun startForegroundIfNeeded(intentServiceParallel: IntentServiceParallel) {
+        TaskerPluginRunner.startForegroundIfNeeded(intentServiceParallel, notificationProperties)
+    }
+
 
     companion object {
         const val NOTIFICATION_CHANNEL_ID = "taskerpluginforegroundd"


### PR DESCRIPTION
`TaskerPluginRunerAction` is always calling  `IntentServiceParallel.startForegroundIfNeeded` which calls `TaskerPluginRunner.startForegroundIfNeeded(this)`, which will always use the default value of `NotificationProperties`.

This fix adds `TaskerPluginRunner.startForegroundIfNeeded(intentServiceParallel: IntentServiceParallel)`, which is called from `TaskerPluginRunnerAction` to properly use the configured `NotificationProperties`.

Before: Notification icon is not displayed properly even though [it is configured](https://github.com/joaomgcd/TaskerPluginSample/blob/994436ebe5bed1c973529ce6a46b8e403490760a/app/src/main/java/com/joaomgcd/taskerpluginsample/tasker/gettime/Runner.kt#L19)
<img width="560" alt="Screen Shot 2021-09-12 at 5 41 21 PM" src="https://user-images.githubusercontent.com/794237/133008673-681f1d87-32b9-41fb-9ee3-643d6ee5482d.png">

After: Notification icon is displayed properly:
<img width="560" alt="Screen Shot 2021-09-12 at 5 40 59 PM" src="https://user-images.githubusercontent.com/794237/133008731-d0136ab7-e316-4158-884c-13565a9fcc8f.png">
