### PR TITLE
Add Progurad/R8 rule for TaskerPluginConfig

### DIFF
--- a/taskerpluginlibrary/proguard-rules.pro
+++ b/taskerpluginlibrary/proguard-rules.pro
@@ -25,7 +25,7 @@
 }
 -keepclassmembers @com.joaomgcd.taskerpluginlibrary.output.TaskerOutputObject class * { *; }
 -keep public class * extends com.joaomgcd.taskerpluginlibrary.runner.TaskerPluginRunner { *; }
-
+-keepclassmembernames class com.joaomgcd.taskerpluginlibrary.config.TaskerPluginConfig { *; }
 
 -keep public class net.dinglisch.android.tasker.PluginResultReceiver { *; }
 


### PR DESCRIPTION
Hi. I noticed that the current Proguard/R8 rules are not sufficient for the `TaskerPluginConfig` interface.

```kotlin
interface TaskerPluginConfig<TInput : Any> {
    // vvv
    val context: Context
    fun finish() 
    fun getIntent(): Intent?
    fun setResult(resultCode: Int, data: Intent)
    // ^^^
    fun assignFromInput(input: TaskerInput<TInput>)
    val inputForTasker: TaskerInput<TInput>
}
```

This interface is used in an unusual way. It is expected to be inherited the interface by a subclass of the Activity class, and the first four methods/properties are implicitly implemented. Therefore, these methods and properties should not be renamed by Proguard/R8.

---

### Environment
- AGP: v8.1.1
- `com.joaomgcd:taskerpluginlibrary`: v0.4.7
